### PR TITLE
Changes from background agent bc-e32d8ccb-daa8-4bdd-991b-41a188a506d4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; object-src 'self';"
   }
 }


### PR DESCRIPTION
Add 'unsafe-eval' to CSP to resolve Vue.js template compilation errors.

The browser extension's Content Security Policy was blocking Vue.js from performing runtime template compilation, leading to `Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script` errors. This change allows Vue to function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e32d8ccb-daa8-4bdd-991b-41a188a506d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e32d8ccb-daa8-4bdd-991b-41a188a506d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

