### PR TITLE
Changes from background agent bc-f98a2aed-757a-4bcf-9c1d-a8235af176c6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
+    "extension_pages": "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; object-src 'self';"
   }
 }

--- a/security-audit.md
+++ b/security-audit.md
@@ -57,13 +57,19 @@ This document provides a comprehensive security audit of the Open AudioAi Chrome
 #### Extension CSP
 ```javascript
 "content_security_policy": {
-  "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
+  "extension_pages": "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; object-src 'self';"
 }
 ```
 - ✅ Strict script source policy
 - ✅ No unsafe-inline allowed
-- ✅ No unsafe-eval (except wasm)
+- ⚠️ Allows unsafe-eval for Vue.js template compilation
 - ✅ Self-only object sources
+
+**Note**: `unsafe-eval` is required for Vue.js runtime template compilation. This is a controlled security risk as:
+- Scripts are only loaded from 'self' (extension files)
+- No external script sources are allowed
+- Vue.js is a trusted, well-audited framework
+- Template compilation is sandboxed within the extension context
 
 ### 5. Extension Permissions
 


### PR DESCRIPTION
Enable Vue.js template compilation by adding `'unsafe-eval'` to the Content Security Policy.

Vue.js requires `'unsafe-eval'` for runtime template compilation, which was previously blocked by the Content Security Policy. This change allows the application to function correctly. The security risk is mitigated as scripts are still restricted to 'self' (extension files), and this change has been documented in `security-audit.md` to reflect the controlled nature of this exception.

---
<a href="https://cursor.com/background-agent?bcId=bc-f98a2aed-757a-4bcf-9c1d-a8235af176c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f98a2aed-757a-4bcf-9c1d-a8235af176c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

