### PR TITLE
Clear access token on logout

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -203,20 +203,7 @@ const App = {
         };
 
         const signInWithGoogle = async () => {
-            if (isLoading.value) return;
-            
-            isLoading.value = true;
-            clearError();
-            
-            try {
-                const token = await getAuthToken();
-                await fetchUserInfo(token);
-            } catch (error) {
-                console.error('Authentication failed:', error);
-                showError('Authentication Failed', 'Please try signing in again.');
-            } finally {
-                isLoading.value = false;
-            }
+            return await signInWithGoogleDifferentAccount();
         };
 
         const fetchUserInfo = async (token) => {

--- a/js/popup.js
+++ b/js/popup.js
@@ -170,7 +170,7 @@ const App = {
                 authUrl.searchParams.set('scope', scopes.join(' '));
                 authUrl.searchParams.set('include_granted_scopes', 'true');
                 authUrl.searchParams.set('prompt', 'select_account');
-                authUrl.searchParams.set('nonce', SecurityUtils.generateNonce());
+                authUrl.searchParams.set('state', SecurityUtils.generateNonce());
 
                 const responseUrl = await new Promise((resolve, reject) => {
                     try {


### PR DESCRIPTION
Force Google account chooser on sign-in to prevent automatic re-login to the previous account.

Even though the extension's token and cache are cleared on logout, the Google account remains signed in at the browser level. This change ensures the user is prompted to select an account when signing in again.

---
<a href="https://cursor.com/background-agent?bcId=bc-98e85580-d0fb-410d-a817-3b6be093bc73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98e85580-d0fb-410d-a817-3b6be093bc73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

