### PR TITLE
Revert to previous version without sign in button

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -148,60 +148,6 @@ const App = {
             }
         };
 
-        // New: OAuth via explicit web auth flow to force account selection
-        const signInWithGoogleDifferentAccount = async () => {
-            if (isLoading.value) return;
-            isLoading.value = true;
-            clearError();
-
-            try {
-                const manifest = chrome.runtime.getManifest();
-                const clientId = manifest?.oauth2?.client_id;
-                const scopes = manifest?.oauth2?.scopes || [];
-                if (!clientId || scopes.length === 0) {
-                    throw new Error('OAuth configuration missing in manifest');
-                }
-
-                const redirectUri = `https://${chrome.runtime.id}.chromiumapp.org/`;
-                const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
-                authUrl.searchParams.set('client_id', clientId);
-                authUrl.searchParams.set('response_type', 'token');
-                authUrl.searchParams.set('redirect_uri', redirectUri);
-                authUrl.searchParams.set('scope', scopes.join(' '));
-                authUrl.searchParams.set('include_granted_scopes', 'true');
-                authUrl.searchParams.set('prompt', 'select_account');
-                authUrl.searchParams.set('nonce', SecurityUtils.generateNonce());
-
-                const responseUrl = await new Promise((resolve, reject) => {
-                    try {
-                        chrome.identity.launchWebAuthFlow({ url: authUrl.toString(), interactive: true }, (redirectedTo) => {
-                            if (chrome.runtime.lastError || !redirectedTo) {
-                                return reject(chrome.runtime.lastError || new Error('Auth flow failed'));
-                            }
-                            resolve(redirectedTo);
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-
-                const hash = new URL(responseUrl).hash || '';
-                const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
-                const token = params.get('access_token');
-                if (!token) {
-                    throw new Error('No access token returned');
-                }
-
-                await chrome.storage.local.set({ authToken: token });
-                await fetchUserInfo(token);
-            } catch (error) {
-                console.error('Authentication (account selection) failed:', error);
-                showError('Authentication Failed', 'Please try again.');
-            } finally {
-                isLoading.value = false;
-            }
-        };
-
         const signInWithGoogle = async () => {
             if (isLoading.value) return;
             
@@ -448,7 +394,6 @@ const App = {
             fileInput,
             // Methods
             signInWithGoogle,
-            signInWithGoogleDifferentAccount,
             logout,
             handleFileSelect,
             handleDrop,
@@ -467,7 +412,7 @@ const App = {
         const { 
             isAuthenticated, isLoading, user, transcript, isProcessing, 
             processingMessage, error, isDragOver, isCopied, showTokenWarning,
-            signInWithGoogle, signInWithGoogleDifferentAccount, logout, handleFileSelect, 
+            signInWithGoogle, logout, handleFileSelect, 
             handleDrop, handleDragOver, handleDragLeave, copyTranscript, sendToChatGPT, 
             resetUpload, clearError, closeTokenWarning, openFileDialog
         } = this;
@@ -498,14 +443,6 @@ const App = {
                 }, [
                     h('img', { src: 'icons/google-logo.png', alt: 'Google', class: 'google-logo' }),
                     h('span', isLoading ? 'Signing in...' : 'Sign in with Google')
-                ]),
-                h('button', {
-                    class: 'google-signin-btn alt',
-                    disabled: isLoading,
-                    onClick: signInWithGoogleDifferentAccount
-                }, [
-                    h('img', { src: 'icons/google-logo.png', alt: 'Google', class: 'google-logo' }),
-                    h('span', isLoading ? 'Opening account chooser...' : 'Sign in with another account')
                 ])
             ]),
 


### PR DESCRIPTION
Remove 'Sign in with another account' button and its associated logic to revert to the previous UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-edc72417-afed-45e7-a7e4-a98b31c07673">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edc72417-afed-45e7-a7e4-a98b31c07673">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

