### PR TITLE
Fix m4a file type validation

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -16,12 +16,20 @@ const SecurityUtils = {
     // Validate file type and size
     validateAudioFile(file) {
         const allowedTypes = [
-            'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/ogg', 
-            'audio/aac', 'audio/m4a', 'audio/flac'
+            'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/ogg',
+            'audio/aac', 'audio/m4a', 'audio/mp4', 'audio/x-m4a', 'audio/flac'
         ];
+        const allowedExtensions = ['mp3', 'wav', 'ogg', 'aac', 'm4a', 'flac'];
         const maxSize = 100 * 1024 * 1024; // 100MB
 
-        if (!allowedTypes.includes(file.type)) {
+        const hasValidMime = !!file.type && allowedTypes.includes(file.type);
+        let extension = '';
+        if (file.name && file.name.indexOf('.') !== -1) {
+            extension = file.name.split('.').pop().toLowerCase();
+        }
+        const hasValidExtension = allowedExtensions.includes(extension);
+
+        if (!hasValidMime && !hasValidExtension) {
             throw new Error('Invalid file type. Please upload an audio file.');
         }
 


### PR DESCRIPTION
Allow `.m4a` audio files to be uploaded by expanding accepted MIME types and adding extension-based validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-54bb2afa-a2b4-4b14-902d-bd1bc208ddeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54bb2afa-a2b4-4b14-902d-bd1bc208ddeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

